### PR TITLE
Embed Updates

### DIFF
--- a/littlesis-core-functionality.php
+++ b/littlesis-core-functionality.php
@@ -7,7 +7,7 @@
  * Author URI:      https://github.com/misfist
  * Text Domain:     littlesis-core
  * Domain Path:     /languages
- * Version:         0.1.4
+ * Version:         0.1.5
  *
  * @package         Littlesis_Core_Functionality
  */
@@ -41,7 +41,7 @@ require_once( 'admin/class-littlesis-core-admin.php' );
  * @return object LittleSis
  */
 function littlesis_core() {
-  $instance = LittleSis_Core::instance( __FILE__, '0.1.4' );
+  $instance = LittleSis_Core::instance( __FILE__, '0.1.5' );
 
  	return $instance;
 }


### PR DESCRIPTION
- Updated  shortcode to remove extra markup and link button; 
- Added oligarcher as oembed source so it can be used as a native embed. It renders correctly, but appears as though it doesn't work in the editor.

https://trello.com/c/4Lr8Fdvx

Note: Once merged, master will need to be tagged with the version in the `composer.json` config file - `0.1.5`. https://github.com/public-accountability/pai-packages/pull/8/commits/504f273a9990d67ed41c221709b7e8b816da8e9c#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780R118